### PR TITLE
Allow env override

### DIFF
--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -14,6 +14,10 @@ hookimpl = pluggy.HookimplMarker("tox")
 @hookimpl
 def tox_configure(config):
     # type: (Config) -> None
+    if 'TOXENV' not in os.environ and not config.option.env:
+        configure_envs(config)
+
+def configure_envs(config):
     verbosity2("original envconfigs: {}".format(list(config.envconfigs.keys())))
     verbosity2("original envlist: {}".format(config.envlist))
     verbosity2("original envlist_default: {}".format(config.envlist_default))


### PR DESCRIPTION
I have to make use of the older version 3.9.0 as that's the last version that had working Jython support. Unfortunately tox-gh-actions runs into an error. Therefore I adapted the code from https://github.com/tox-dev/tox-travis as it runs with the older version - at least with my particular travis.yml file that sets the TOXENV explicitly for Jython.

    Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.6.10/x64/bin/tox", line 8, in <module>
        sys.exit(cmdline())
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/tox/session/__init__.py", line 43, in cmdline
        main(args)
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/tox/session/__init__.py", line 63, in main
        config = load_config(args)
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/tox/session/__init__.py", line 80, in load_config
        config = parseconfig(args)
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/tox/config/__init__.py", line 255, in parseconfig
        pm.hook.tox_configure(config=config)  # post process config object
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/pluggy/hooks.py", line 286, in __call__
        return self._hookexec(self, self.get_hookimpls(), kwargs)
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/pluggy/manager.py", line 93, in _hookexec
        return self._inner_hookexec(hook, methods, kwargs)
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/pluggy/manager.py", line 87, in <lambda>
        firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/pluggy/callers.py", line 208, in _multicall
        return outcome.get_result()
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/pluggy/callers.py", line 80, in get_result
        raise ex[1].with_traceback(ex[2])
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/pluggy/callers.py", line 187, in _multicall
        res = hook_impl.function(*args)
    File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/site-packages/tox_gh_actions/plugin.py", line 19, in tox_configure
        verbosity2("original envlist_default: {}".format(config.envlist_default))
    AttributeError: 'Config' object has no attribute 'envlist_default'

envlist_default does not exist in 3.9.0.