### PR TITLE
Require tox 3.12 or above

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
 zip_safe = True
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 install_requires =
-    tox >= 3.12.2
+    tox >= 3.12
     typing; python_version<"3.5"
 setup_requires =
     setuptools_scm >= 3, <4


### PR DESCRIPTION
Require tox 3.12 or above instead of 3.12.2 or above because 3.12.2
doesn't exist and there's no special reasons to disallow 3.12.0.