### PR TITLE
Check whether tox is running on Actions or not using GITHUB_ACTIONS

### DIFF
--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -28,7 +28,7 @@ def tox_configure(config):
     envlist = get_envlist_from_factors(config.envlist, factors)
     verbosity2("new envlist: {}".format(envlist))
 
-    if "GITHUB_ACTION" not in os.environ:
+    if not is_running_on_actions():
         verbosity1("tox is not running in GitHub Actions")
         verbosity1("tox-gh-actions won't override envlist")
         return
@@ -89,6 +89,14 @@ def get_python_version():
         return "pypy" + str(sys.version_info[0])
     # Assuming running on CPython
     return '.'.join([str(i) for i in sys.version_info[:2]])
+
+
+def is_running_on_actions():
+    # type: () -> bool
+    """Returns True when running on GitHub Actions"""
+    # See the following document on which environ to use for this purpose.
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+    return os.environ.get("GITHUB_ACTIONS") == "true"
 
 
 # The following function was copied from

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -282,3 +282,13 @@ def test_get_version(mocker, version, info, expected):
     mocker.patch("tox_gh_actions.plugin.sys.version", version)
     mocker.patch("tox_gh_actions.plugin.sys.version_info", info)
     assert plugin.get_python_version() == expected
+
+
+@pytest.mark.parametrize("environ,expected", [
+    ({"GITHUB_ACTIONS": "true"}, True),
+    ({"GITHUB_ACTIONS": "false"}, False),
+    ({}, False),
+])
+def test_is_running_on_actions(mocker, environ, expected):
+    mocker.patch("tox_gh_actions.plugin.os.environ", environ)
+    assert plugin.is_running_on_actions() == expected


### PR DESCRIPTION
Use GITHUB_ACTIONS instead of GITHUB_ACTION as the documentation
recommends to use GITHUB_ACTIONS for this purpose.
https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables

This is technically a breaking change but shouldn't break builds unless users are overriding `GITHUB_ACTION*` environment variables explicitly.