### PR TITLE
Group log lines for each test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 with multiple different Python versions on multiple workers in parallel.
 This project is inspired by [tox-travis](https://github.com/tox-dev/tox-travis).
 
+## Features
+When running tox on GitHub Actions, tox-gh-actions
+* detects which environment to run based on configurations and
+* privides utilities such as [grouping log lines](https://github.com/actions/toolkit/blob/main/docs/commands.md#group-and-ungroup-log-lines).
+
 ## Usage
 1. Add configurations under `[gh-actions]` section along with tox's configuration.
    - It will be `pyproject.toml`, `tox.ini`, or `setup.cfg`. See [tox's documentation](https://tox.readthedocs.io/en/latest/config.html) for more details.

--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -35,6 +35,20 @@ def tox_configure(config):
     config.envlist_default = config.envlist = envlist
 
 
+@hookimpl
+def tox_runtest_pre(venv):
+    # type: (Any) -> None
+    if is_running_on_actions():
+        print("::group::tox: " + venv.name)
+
+
+@hookimpl
+def tox_runtest_post(venv):
+    # type: (Any) -> None
+    if is_running_on_actions():
+        print("::endgroup::")
+
+
 def parse_config(config):
     # type: (Dict[str, Dict[str, str]]) -> Dict[str, Dict[str, Any]]
     """Parse gh-actions section in tox.ini"""


### PR DESCRIPTION
Closes #32.

When running on GitHub Actions, group log lines when running tests in each environment.

[![Image from Gyazo](https://i.gyazo.com/b381e71b9f0e02dae1867303fa97a12b.png)](https://gyazo.com/b381e71b9f0e02dae1867303fa97a12b)