### PR TITLE
Run tests against Python 3.9 and add trove classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
           - ubuntu-latest  # ubuntu-18.04
           - macos-latest  # macOS-10.14
           - windows-latest  # windows-2019
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 packages = find:
@@ -72,7 +73,7 @@ isolated_build = true
 skip_missing_interpreters = true
 envlist =
     flake8
-    py{27,35,36,37,38}-tox{312,315,latest}
+    py{27,35,36,37,38,39}-tox{312,315,latest}
 
 [gh-actions]
 python =
@@ -81,6 +82,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38, flake8
+    3.9: py39
 
 [testenv]
 description = run test suite under {basepython}


### PR DESCRIPTION
Is anything else required to ensure Python 3.9 compatibility?

Closes ymyzk/tox-gh-actions#33