### PR TITLE
doc: Update README to suggest to run on both push and pull_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ python =
 ```yaml
 name: Python package
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:
@@ -185,7 +187,9 @@ It will create 12 jobs when running the workflow on GitHub Actions.
 ```yaml
 name: Python package
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
Former Travis CI users would typically use a Travis CI run as a status check on a GitHub pull request, blocking the PR from being merged until all Travis tests complete.

With GitHub Actions workflows, the same is possible -- as long as the workflow runs on `pull_request`. This is not easy to find out for people new to GitHub Actions workflows, so it's probably a good idea to have it in the README.

Thus, update the README examples to suggest that the workflow be triggered not only on `push`, but also on `pull_request`, to facilitate this typical configuration.

See https://github.community/t/github-actions-as-status-checks/16666/13 for a GitHub community discussion reflecting users being confused about this feature.