### PR TITLE
Limit tox version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     tox >=3.12, <4
     typing; python_version<"3.5"
 setup_requires =
-    setuptools_scm >= 3, <4
+    setuptools_scm >=3, <4
 
 [options.packages.find]
 where = src
@@ -57,11 +57,11 @@ tox =
 [options.extras_require]
 testing =
     black; platform_python_implementation=='CPython' and python_version>='3.6'
-    flake8 >= 3, <4
-    pytest >= 4.0.0, <6
-    pytest-cov >= 2, <3
-    pytest-mock >= 2, <3
-    pytest-randomly >= 3; python_version>='3.5'
+    flake8 >=3, <4
+    pytest >=4, <6
+    pytest-cov >=2, <3
+    pytest-mock >=2, <3
+    pytest-randomly >=3; python_version>='3.5'
 
 [options.package_data]
 tox_gh_actions =

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ package_dir =
 zip_safe = True
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 install_requires =
-    tox >= 3.12
+    tox >=3.12, <4
     typing; python_version<"3.5"
 setup_requires =
     setuptools_scm >= 3, <4


### PR DESCRIPTION
To avoid accidentally upgrading to tox v4 where we expect breaking changes.