### PR TITLE
tox4: Remove support for Python 2.7 and 3.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - macos-latest  # macOS-10.15
           - windows-2016
           - windows-latest  # windows-2019
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy-2.7, pypy-3.6, pypy-3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ When running tox on GitHub Actions, tox-gh-actions
 
 ## Examples
 ### Basic Example
-The following configuration will create 5 jobs when running the workflow on GitHub Actions.
-- On Python 2.7 job, tox runs `py27` environment
+The following configuration will create 4 jobs when running the workflow on GitHub Actions.
 - On Python 3.6 job, tox runs `py36` environment
 - On Python 3.7 job, tox runs `py37` environment
 - On Python 3.8 job, tox runs `py38` and `mypy` environments
@@ -34,11 +33,10 @@ Add `[gh-actions]` section to the same file as tox's configuration.
 If you're using `tox.ini`:
 ```ini
 [tox]
-envlist = py27, py36, py37, py38, py39, mypy
+envlist = py36, py37, py38, py39, mypy
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38, mypy
@@ -51,11 +49,10 @@ python =
 If you're using `setup.cfg`:
 ```ini
 [tox:tox]
-envlist = py27, py36, py37, py38, py39, mypy
+envlist = py36, py37, py38, py39, mypy
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38, mypy
@@ -70,11 +67,10 @@ If you're using `pyproject.toml`:
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py27, py36, py37, py38, py39, mypy
+envlist = py36, py37, py38, py39, mypy
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38, mypy
@@ -98,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1
@@ -117,18 +113,18 @@ jobs:
 ### Advanced Examples
 #### Factor-Conditional Settings: Python Version
 The following configuration will create 2 jobs when running the workflow on GitHub Actions.
-- On Python 2.7 job, tox runs `py27-django111` environment
-- On Python 3.7 job, tox runs `py37-django111` and `py37-django20` environments
+- On Python 3.7 job, tox runs `py37-django22` and `py37-django32` environments
+- On Python 3.8 job, tox runs `py38-django32` environment
 
 `tox.ini`:
 ```ini
 [tox]
-envlist = py27-django{111}, py37-django{111,20}
+envlist = py37-django{22,32}, py38-django32
 
 [gh-actions]
 python =
-    2.7: py27
     3.7: py37
+    3.8: py38
 
 [testenv]
 ...
@@ -170,15 +166,14 @@ Support of Pyston is experimental and not tested by our CI.
  `tox.ini`:
 ```ini
 [tox]
-envlist = py27, py38, pypy2, pypy3, pyston38
+envlist = py37, py38, pypy3, pyston38
 
 [gh-actions]
 python =
-    2.7: py27
+    3.7: py37
     3.8: py38, mypy
-    pypy-2.7: pypy2
     pypy-3.7: pypy3
-    pyston-3.8: python38
+    pyston-3.8: pyston38
 
 [testenv]
 ...
@@ -192,14 +187,12 @@ You can also specify without minor versions in the `python` configuration key.
 `tox.ini`:
 ```ini
 [tox]
-envlist = py2, py3, pypy2, pypy3
+envlist = py3, pypy3
 
 [gh-actions]
 python =
-    2: py2
     3: py3, mypy
-    # pypy2 and pypy3 are still supported for backward compatibility
-    pypy-2: pypy2
+    # pypy3 are still supported for backward compatibility
     pypy-3: pypy3
 
 [testenv]
@@ -213,9 +206,9 @@ tox-gh-actions gets factors only from the key `3.8`.
 #### Factor-Conditional Settings: Environment Variable
 You can also use environment variable to decide which environment to run.
 The following is an example to install different dependency based on platform.
-It will create 12 jobs when running the workflow on GitHub Actions.
-- On Python 2.7/ubuntu-latest job, tox runs `py27-linux` environment
-- On Python 3.5/ubuntu-latest job, tox runs `py35-linux` environment
+It will create 9 jobs when running the workflow on GitHub Actions.
+- On Python 3.6/ubuntu-latest job, tox runs `py36-linux` environment
+- On Python 3.7/ubuntu-latest job, tox runs `py37-linux` environment
 - and so on.
 
 `.github/workflows/<workflow>.yml`:
@@ -232,7 +225,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1
@@ -253,14 +246,13 @@ jobs:
 `tox.ini`:
 ```ini
 [tox]
-envlist = py{27,36,37,38}-{linux,macos,windows}
+envlist = py{36,37,38}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    2.7: py27
-    3.8: py38, mypy
-    pypy-2.7: pypy2
-    pypy-3.7: pypy3
+    3.6: py36
+    3.7: py37
+    3.8: py38
 
 [gh-actions:env]
 PLATFORM =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,15 @@ requires = [
     # For PEP 517 and PEP 518 support
     # https://pip.pypa.io/en/stable/cli/pip/#pep-517-and-518-support
     # setuptools_scm v6 requires setuptools >= 45
-    "setuptools >= 40.8.0",
-    # Needs setuptools_scm v5 for Python <3.6
-    "setuptools_scm[toml] >= 5, <7",
+    "setuptools >= 45",
+    "setuptools_scm[toml] >= 6, <7",
     "wheel",
 ]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
 # py39 is not supported yet
-target-version = ["py27", "py35", "py36", "py37", "py38"]
+target-version = ["py36", "py37", "py38"]
 
 [tool.coverage.paths]
 # For combining source file paths correctly

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,10 +24,8 @@ classifiers =
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Libraries
     Topic :: Utilities
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -40,14 +38,11 @@ packages = find:
 package_dir =
   =src
 zip_safe = True
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.6
 install_requires =
     tox >=3.12, <4
-    typing; python_version<"3.5"
 setup_requires =
-    # This is for backward compatibility
-    # Needs setuptools_scm v5 for Python <3.6
-    setuptools_scm[toml] >=5, <7
+    setuptools_scm[toml] >=6, <7
 
 [options.packages.find]
 where = src
@@ -58,12 +53,12 @@ tox =
 
 [options.extras_require]
 testing =
-    black; platform_python_implementation=='CPython' and python_version>='3.6'
+    black; platform_python_implementation=='CPython'
     flake8 >=3, <4
     pytest >=4, <6
     pytest-cov >=2, <3
     pytest-mock >=2, <3
-    pytest-randomly >=3; python_version>='3.5'
+    pytest-randomly >=3
 
 [options.package_data]
 tox_gh_actions =
@@ -79,12 +74,10 @@ skip_missing_interpreters = true
 envlist =
     black
     flake8
-    {py27,py35,py36,py37,py38,py39,pypy2,pypy3}-tox{312,315,latest}
+    {py36,py37,py38,py39,pypy2,pypy3}-tox{312,315,latest}
 
 [gh-actions]
 python =
-    2.7: py27, flake8
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38, black, flake8

--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -116,9 +116,7 @@ def get_python_version_keys():
     """Get Python version in string for getting factors from gh-action's config
 
     Examples:
-    - CPython 2.7.z => [2.7, 2]
     - CPython 3.8.z => [3.8, 3]
-    - PyPy 2.7 (v7.3.z) => [pypy-2.7, pypy-2, pypy2]
     - PyPy 3.6 (v7.3.z) => [pypy-3.6, pypy-3, pypy3]
     - Pyston based on Python CPython 3.8.8 (v2.2) => [pyston-3.8, pyston-3]
 

--- a/tests/integration/tox.ini
+++ b/tests/integration/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27, py39, unused
+envlist = py38, py39, unused
 skipsdist = True
 
 [gh-actions]
 python =
-    2.7: py27
+    3.8: py38
     3.9: py39
 
 [testenv]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,7 +26,7 @@ def test_integration():
     expected_envs_map = defaultdict(
         list,
         [
-            ((2, 7), ["py27"]),
+            ((3, 8), ["py38"]),
             ((3, 9), ["py39"]),
         ],
     )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,18 +10,16 @@ from tox_gh_actions import plugin
         (
             {
                 "gh-actions": {
-                    "python": """2.7: py27
-3.5: py35
-3.6: py36
-3.7: py37, flake8"""
+                    "python": """3.7: py37
+3.8: py38
+3.9: py39, flake8"""
                 }
             },
             {
                 "python": {
-                    "2.7": ["py27"],
-                    "3.5": ["py35"],
-                    "3.6": ["py36"],
-                    "3.7": ["py37", "flake8"],
+                    "3.7": ["py37"],
+                    "3.8": ["py38"],
+                    "3.9": ["py39", "flake8"],
                 },
                 "env": {},
             },
@@ -29,7 +27,7 @@ from tox_gh_actions import plugin
         (
             {
                 "gh-actions": {
-                    "python": """2.7: py27
+                    "python": """3.7: py37
 3.8: py38"""
                 },
                 "gh-actions:env": {
@@ -40,7 +38,7 @@ windows-latest: windows"""
             },
             {
                 "python": {
-                    "2.7": ["py27"],
+                    "3.7": ["py37"],
                     "3.8": ["py38"],
                 },
                 "env": {
@@ -78,14 +76,14 @@ def test_parse_config(config, expected):
         (
             {
                 "python": {
-                    "2.7": ["py27", "flake8"],
+                    "3.7": ["py37", "flake8"],
                     "3.8": ["py38", "flake8"],
                 },
                 "unknown": {},
             },
-            ["2.7", "2"],
+            ["3.7", "3"],
             {},
-            ["py27", "flake8"],
+            ["py37", "flake8"],
         ),
         # Get factors using less precise Python version
         (
@@ -117,7 +115,7 @@ def test_parse_config(config, expected):
         (
             {
                 "python": {
-                    "2.7": ["py27", "flake8"],
+                    "3.7": ["py37", "flake8"],
                     "3.8": ["py38", "flake8"],
                 },
                 "env": {
@@ -127,17 +125,17 @@ def test_parse_config(config, expected):
                     },
                 },
             },
-            ["2.7", "2"],
+            ["3.7", "3"],
             {
                 "SAMPLE": "VALUE1",
                 "HOGE": "VALUE3",
             },
-            ["py27-fact1", "py27-fact2", "flake8-fact1", "flake8-fact2"],
+            ["py37-fact1", "py37-fact2", "flake8-fact1", "flake8-fact2"],
         ),
         (
             {
                 "python": {
-                    "2.7": ["py27", "flake8"],
+                    "3.7": ["py37", "flake8"],
                     "3.8": ["py38", "flake8"],
                 },
                 "env": {
@@ -151,16 +149,16 @@ def test_parse_config(config, expected):
                     },
                 },
             },
-            ["2.7", "2"],
+            ["3.7", "3"],
             {
                 "SAMPLE": "VALUE1",
                 "HOGE": "VALUE3",
             },
             [
-                "py27-fact1-fact5",
-                "py27-fact1-fact6",
-                "py27-fact2-fact5",
-                "py27-fact2-fact6",
+                "py37-fact1-fact5",
+                "py37-fact1-fact6",
+                "py37-fact2-fact5",
+                "py37-fact2-fact6",
                 "flake8-fact1-fact5",
                 "flake8-fact1-fact6",
                 "flake8-fact2-fact5",
@@ -170,7 +168,7 @@ def test_parse_config(config, expected):
         (
             {
                 "python": {
-                    "2.7": ["py27", "flake8"],
+                    "3.7": ["py37", "flake8"],
                     "3.8": ["py38", "flake8"],
                 },
                 "env": {
@@ -180,14 +178,14 @@ def test_parse_config(config, expected):
                     },
                 },
             },
-            ["2.7", "2"],
+            ["3.7", "3"],
             {
                 "SAMPLE": "VALUE1",
                 "HOGE": "VALUE3",
             },
             [
-                "py27-django18",
-                "py27-flake8",
+                "py37-django18",
+                "py37-flake8",
                 "flake8-django18",
                 "flake8-flake8",
             ],
@@ -195,7 +193,7 @@ def test_parse_config(config, expected):
         (
             {
                 "python": {
-                    "2.7": ["py27", "flake8"],
+                    "3.7": ["py37", "flake8"],
                     "3.8": ["py38", "flake8"],
                 },
                 "env": {
@@ -206,16 +204,16 @@ def test_parse_config(config, expected):
                 },
                 "unknown": {},
             },
-            ["2.7", "2"],
+            ["3.7", "3"],
             {
                 "SAMPLE": "VALUE3",
             },
-            ["py27", "flake8"],
+            ["py37", "flake8"],
         ),
         (
             {
                 "python": {
-                    "2.7": ["py27", "flake8"],
+                    "3.7": ["py37", "flake8"],
                     "3.8": ["py38", "flake8"],
                 },
                 "env": {
@@ -237,7 +235,7 @@ def test_parse_config(config, expected):
                     "3.8": ["py38", "flake8"],
                 },
             },
-            ["2.7", "2"],
+            ["3.7", "3"],
             {},
             [],
         ),
@@ -269,12 +267,12 @@ def normalize_factors_list(factors):
     "envlist,factors,expected",
     [
         (
-            ["py27", "py37", "flake8"],
-            ["py37", "flake8"],
-            ["py37", "flake8"],
+            ["py37", "py38", "flake8"],
+            ["py38", "flake8"],
+            ["py38", "flake8"],
         ),
         (
-            ["py27", "py37", "flake8"],
+            ["py37", "py38", "flake8"],
             [],
             [],
         ),
@@ -284,19 +282,19 @@ def normalize_factors_list(factors):
             [],
         ),
         (
-            ["py27-dj111", "py37-dj111", "py37-dj20", "flake8"],
-            ["py37", "flake8"],
-            ["py37-dj111", "py37-dj20", "flake8"],
+            ["py37-dj111", "py38-dj111", "py38-dj20", "flake8"],
+            ["py38", "flake8"],
+            ["py38-dj111", "py38-dj20", "flake8"],
         ),
         (
-            ["py27-django18", "py37-django18", "flake8"],
+            ["py37-django18", "py38-django18", "flake8"],
             [
-                "py27-django18",
-                "py27-flake8",
+                "py37-django18",
+                "py37-flake8",
                 "flake8-django18",
                 "flake8-flake8",
             ],
-            ["py27-django18", "flake8"],
+            ["py37-django18", "flake8"],
         ),
     ],
 )
@@ -317,12 +315,6 @@ def test_get_envlist_from_factors(envlist, factors, expected):
             "[PyPy 7.3.0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]",
             (3, 6, 9, "final", 0),
             ["pypy-3.6", "pypy-3", "pypy3"],
-        ),
-        (
-            "2.7.13 (724f1a7d62e8, Dec 23 2019, 15:36:24)\n"
-            "[PyPy 7.3.0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]",
-            (2, 7, 13, "final", 42),
-            ["pypy-2.7", "pypy-2", "pypy2"],
         ),
     ],
 )
@@ -367,9 +359,9 @@ def test_is_running_on_actions(mocker, environ, expected):
     "option_env,environ,expected",
     [
         (None, {"TOXENV": "flake8"}, True),
-        (["py27,py38"], {}, True),
-        (["py27", "py38"], {}, True),
-        (["py27"], {"TOXENV": "flake8"}, True),
+        (["py37,py38"], {}, True),
+        (["py37", "py38"], {}, True),
+        (["py37"], {"TOXENV": "flake8"}, True),
         (None, {}, False),
     ],
 )


### PR DESCRIPTION
tox v4 supports only Python 3.6 or later. It's nice to drop support of old versions before making large changes. #59 