### PR TITLE
tox4: Drop support of old-style PyPy key (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ envlist = py3, pypy3
 [gh-actions]
 python =
     3: py3, mypy
-    # pypy3 are still supported for backward compatibility
     pypy-3: pypy3
 
 [testenv]
@@ -202,6 +201,8 @@ python =
 If there are multiple matching Python versions in the configuration, only the most precise one is used.
 For example, if you are running CPython 3.8 and `gh-actions.python` has both `3` and `3.8`,
 tox-gh-actions gets factors only from the key `3.8`.
+
+_Changed in 3.0_: `pypy3` is not supported in the configuration anymore. Please use `pypy-3` instead.
 
 #### Factor-Conditional Settings: Environment Variable
 You can also use environment variable to decide which environment to run.

--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -119,9 +119,6 @@ def get_python_version_keys():
     - CPython 3.8.z => [3.8, 3]
     - PyPy 3.6 (v7.3.z) => [pypy-3.6, pypy-3, pypy3]
     - Pyston based on Python CPython 3.8.8 (v2.2) => [pyston-3.8, pyston-3]
-
-    Support of "pypy2" and "pypy3" is for backward compatibility with
-    tox-gh-actions v2.2.0 and before.
     """
     major_version = str(sys.version_info[0])
     major_minor_version = ".".join([str(i) for i in sys.version_info[:2]])
@@ -129,7 +126,6 @@ def get_python_version_keys():
         return [
             "pypy-" + major_minor_version,
             "pypy-" + major_version,
-            "pypy" + major_version,
         ]
     elif hasattr(sys, "pyston_version_info"):  # Pyston
         return [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -314,7 +314,7 @@ def test_get_envlist_from_factors(envlist, factors, expected):
             "3.6.9 (1608da62bfc7, Dec 23 2019, 10:50:04)\n"
             "[PyPy 7.3.0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]",
             (3, 6, 9, "final", 0),
-            ["pypy-3.6", "pypy-3", "pypy3"],
+            ["pypy-3.6", "pypy-3"],
         ),
     ],
 )


### PR DESCRIPTION
#59 

The following config is not supported anymore.
```
[gh-actions]
python =
    pypy3: pypy3
```

Please use `pypy-3` which was introduced in https://github.com/ymyzk/tox-gh-actions/releases/tag/v2.3.0
```
[gh-actions]
python =
    pypy-3: pypy3
```