### PR TITLE
Upgrade pytest and pytest-mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,10 @@ source = [
    "*/site-packages",
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: mark as an integration test.",
+]
+
 [tool.setuptools_scm]
 write_to = "src/tox_gh_actions/version.py"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-# This section can be moved to pyproject.toml with pytest 6 or later
-[pytest]
-markers =
-    integration: mark as an integration test.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,9 +56,9 @@ testing =
     black; platform_python_implementation=='CPython'
     flake8 >=3, <4
     mypy; platform_python_implementation=='CPython'
-    pytest >=4, <6
+    pytest >=6, <7
     pytest-cov >=2, <3
-    pytest-mock >=2, <3
+    pytest-mock >=3, <4
     pytest-randomly >=3
 
 [options.package_data]


### PR DESCRIPTION
### Description
* Upgrade pytest and pytest-mock because tox v4 version doesn't need to support Python 2.
* Move pytest.ini into pyproject.toml which is supported by pytest 6.0 and later.

### Expected Behavior
No regressions.