### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - macos-latest  # macOS-10.15
           - windows-2016
           - windows-latest  # windows-2019
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy-2.7, pypy-3.6, pypy-3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2, pypy-2.7, pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 
@@ -80,7 +81,7 @@ skip_missing_interpreters = true
 envlist =
     black
     flake8
-    {py27,py35,py36,py37,py38,py39,pypy2,pypy3}-tox{312,315,latest}
+    {py27,py35,py36,py37,py38,py39,py310,pypy2,pypy3}-tox{312,315,latest}
 
 [gh-actions]
 python =
@@ -90,6 +91,7 @@ python =
     3.7: py37
     3.8: py38, black, flake8
     3.9: py39
+    3.10: py310
     pypy-2: pypy2
     pypy-3: pypy3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,8 @@ tox =
 testing =
     black; platform_python_implementation=='CPython' and python_version>='3.6'
     flake8 >=3, <4
-    pytest >=4, <6
+    pytest >=4, <7; python_version<'3.10'
+    pytest >=6.2.5, <7; python_version>='3.10'
     pytest-cov >=2, <3
     pytest-mock >=2, <3
     pytest-randomly >=3; python_version>='3.5'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -106,13 +106,13 @@ def test_parse_config(config, expected):
                 "python": {
                     "2": ["py2", "flake8"],
                     "3": ["py3", "flake8"],
-                    "3.9": ["py39"],
+                    "3.10": ["py310"],
                 },
                 "unknown": {},
             },
-            ["3.9", "3"],
+            ["3.10", "3"],
             {},
-            ["py39"],
+            ["py310"],
         ),
         (
             {


### PR DESCRIPTION
### Description
* Add Python 3.10 support: https://www.python.org/dev/peps/pep-0619/
  * Update CI config
  * Update package metadata

### Expected Behavior
tox-gh-actions runs on Python 3.10 as well without issues.