### PR TITLE
Start log line grouping earlier when possible

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,24 @@ from tox.config import Config
 from tox_gh_actions import plugin
 
 
+def test_start_grouping_if_necessary(capsys, mocker):
+    envconfig = mocker.MagicMock()
+    envconfig.envname = "test123"
+    envconfig.description = "This is a test environment."
+    venv = mocker.MagicMock()
+    venv.envconfig = envconfig
+
+    # Start grouping in the first call
+    plugin.start_grouping_if_necessary(venv)
+    out1, _ = capsys.readouterr()
+    assert out1 == "::group::tox: test123 - This is a test environment.\n"
+
+    # Should not start groping again in the second call
+    plugin.start_grouping_if_necessary(venv)
+    out2, _ = capsys.readouterr()
+    assert out2 == ""
+
+
 @pytest.mark.parametrize(
     "config,expected",
     [


### PR DESCRIPTION
### Description
tox-gh-actions writes `::group::tox: ...` earlier if possible using other existing hooks provided by tox.
It shouldn't write the same `::group::tox: ...` multiple times.

This PR mitigates the problem described in #39 and #80. 

### Expected Behavior
Before
```
py39-macos create: .tox/py39-macos
py39-macos installdeps: flake8
py39-macos inst: .tox/.tmp/package/1/UNKNOWN-0.0.0.zip
py39-macos installed: flake8==3.9.2,mccabe==0.6.1,pycodestyle==2.7.0,pyflakes==2.3.1,UNKNOWN @ .tox/.tmp/package/1/UNKNOWN-0.0.0.zip
::group::tox: py39-macos
py39-macos run-test-pre: PYTHONHASHSEED='1271455815'
py39-macos run-test: commands[0] | flake8
::endgroup::
```

After
```
py39-macos create: .tox/py39-macos
::group::tox: py39-macos
py39-macos installdeps: flake8
py39-macos inst: .tox/.tmp/package/1/UNKNOWN-0.0.0.zip
py39-macos installed: flake8==3.9.2,mccabe==0.6.1,pycodestyle==2.7.0,pyflakes==2.3.1,UNKNOWN @ .tox/.tmp/package/1/UNKNOWN-0.0.0.zip
py39-macos run-test-pre: PYTHONHASHSEED='1271455815'
py39-macos run-test: commands[0] | flake8
::endgroup::
```