### PR TITLE
Disable log line grouping for isolated build environment

### DIFF
--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -95,6 +95,11 @@ def start_grouping_if_necessary(venv):
     envconfig = venv.envconfig  # type: TestenvConfig
     envname = envconfig.envname
 
+    # Do not enable grouping for an environment used for isolated build
+    # because we don't have a hook to write "::endgroup::" for this environment.
+    if envname == envconfig.config.isolated_build_env:
+        return
+
     if thread_locals.is_grouping_started.get(envname, False):
         return
     thread_locals.is_grouping_started[envname] = True

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -22,6 +22,20 @@ def test_start_grouping_if_necessary(capsys, mocker):
     assert out2 == ""
 
 
+def test_start_grouping_ignores_isolated_build_env(capsys, mocker):
+    envconfig = mocker.MagicMock()
+    envconfig.envname = ".package"
+    envconfig.description = "isolated packaging environment"
+    envconfig.config.isolated_build_env = ".package"
+    venv = mocker.MagicMock()
+    venv.envconfig = envconfig
+
+    # Start grouping in the first call
+    plugin.start_grouping_if_necessary(venv)
+    out, _ = capsys.readouterr()
+    assert out == ""
+
+
 @pytest.mark.parametrize(
     "config,expected",
     [


### PR DESCRIPTION
### Description
Improvement of #90.

Prevent writing `::group::tox: .package - isolated packaging environment` as the plugin cannot write `::endgroup::` for this special isolated build environment.