### PR TITLE
tox4: Use plugin API provided by tox 4.0.0a9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
 zip_safe = True
 python_requires = >=3.6
 install_requires =
-    tox >= 4.0.0a8, <5
+    tox >= 4.0.0a9, <5
 setup_requires =
     setuptools_scm[toml] >=6, <7
 


### PR DESCRIPTION
### Description
Update for using new plugin APIs provided by tox 4.0.0a9.

### Expected Behavior
Basic functionality works on tox 4.0.0a9.