### PR TITLE
Run tests on Python 3.10 stable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - macos-latest  # macOS-10.15
           - windows-2016
           - windows-latest  # windows-2019
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2, pypy-3.6, pypy-3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy-3.6, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
### Description
Use stable Python 3.10 on CI for the tox4 branch.

### Expected Behavior
No regressions