### PR TITLE
Consistently qualify pip install steps within GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        python -m pip install tox tox-gh-actions
     - name: Test with tox
       run: tox
 ```
@@ -266,7 +266,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        python -m pip install tox tox-gh-actions
     - name: Test with tox
       run: tox
       env:


### PR DESCRIPTION
### Description

Fully qualify `python -m pip` invocations. This keeps the example more consistent with the previous line.