### PR TITLE
tox4: Drop Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,7 @@ jobs:
           - macos-latest  # macOS-10.15
           - windows-2016
           - windows-latest  # windows-2019
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', pypy-3.6, pypy-3.7]
-        exclude:
-          # https://github.com/actions/setup-python/issues/311
-          - platform: macos-latest
-            python-version: pypy-3.6
+        python-version: [3.7, 3.8, 3.9, '3.10', pypy-3.7]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ _Changed in 3.0_: `pypy3` is not supported in the configuration anymore. Please 
 You can also use environment variable to decide which environment to run.
 The following is an example to install different dependency based on platform.
 It will create 9 jobs when running the workflow on GitHub Actions.
-- On Python 3.6/ubuntu-latest job, tox runs `py36-linux` environment
-- On Python 3.7/ubuntu-latest job, tox runs `py37-linux` environment
+- On Python 3.8/ubuntu-latest job, tox runs `py38-linux` environment
+- On Python 3.9/ubuntu-latest job, tox runs `py39-linux` environment
 - and so on.
 
 `.github/workflows/<workflow>.yml`:
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1
@@ -270,13 +270,13 @@ jobs:
 `tox.ini`:
 ```ini
 [tox]
-envlist = py{36,37,38}-{linux,macos,windows}
+envlist = py{38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
+    3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 PLATFORM =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
-target-version = ["py36", "py37", "py38", "py39"]
+target-version = ["py37", "py38", "py39"]
 
 [tool.coverage.paths]
 # For combining source file paths correctly

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -40,7 +39,7 @@ packages = find:
 package_dir =
   =src
 zip_safe = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     tox >= 4.0.0a9, <5
 setup_requires =
@@ -79,11 +78,10 @@ envlist =
     black
     flake8
     mypy
-    {py36,py37,py38,py39,py310,pypy2,pypy3}-toxlatest
+    {py37,py38,py39,py310,pypy2,pypy3}-toxlatest
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, black, flake8
     3.9: py39, mypy


### PR DESCRIPTION
### Description
Drop support of Python 3.6: https://www.python.org/dev/peps/pep-0494/