### PR TITLE
Add problem matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ please check [the tox4 branch](https://github.com/ymyzk/tox-gh-actions/tree/tox4
 ## Features
 When running tox on GitHub Actions, tox-gh-actions
 * detects which environment to run based on configurations and
-* provides utilities such as [grouping log lines](https://github.com/actions/toolkit/blob/main/docs/commands.md#group-and-ungroup-log-lines).
+* provides utilities such as [grouping log lines](https://github.com/actions/toolkit/blob/main/docs/commands.md#group-and-ungroup-log-lines)
+  and [annotating error messages](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md).
 
 ## Usage
 1. Add configurations under `[gh-actions]` section along with tox's configuration.

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ package_dir =
 zip_safe = True
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 install_requires =
+    importlib_resources
     tox >=3.12, <4
     typing; python_version<"3.5"
 setup_requires =
@@ -71,6 +72,7 @@ testing =
 
 [options.package_data]
 tox_gh_actions =
+    matcher.json
     py.typed
 
 [bdist_wheel]

--- a/src/tox_gh_actions/matcher.json
+++ b/src/tox_gh_actions/matcher.json
@@ -1,0 +1,24 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "tox-gh-actions-warning-error",
+            "pattern": [
+                {
+                    "regexp": "^(WARNING|ERROR): (.+)$",
+                    "message": 2,
+                    "severity": 1
+                }
+            ]
+        },
+        {
+            "owner": "tox-gh-actions-deprecation-warning",
+            "pattern": [
+                {
+                    "regexp": "^(DEPRECATION (WARNING): .+)$",
+                    "message": 1,
+                    "severity": 2
+                }
+            ]
+        }
+    ]
+}

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,89 @@
+import json
+import re
+
+from tox_gh_actions.plugin import get_problem_matcher_file_path
+
+
+def match_problem(log):
+    """Simulate GitHub Actions' problem matcher for ease of testing
+
+    This is not the same as the actual implementation by GitHub Actions.
+    https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+    """
+    with open(get_problem_matcher_file_path()) as f:
+        matchers = json.load(f)
+    results = []
+    for line in log.split("\n"):
+        for matcher in matchers["problemMatcher"]:
+            # TODO Add multi-lines matcher support if necessary
+            pattern = matcher["pattern"][0]
+            match = re.search(pattern["regexp"], line)
+            if not match:
+                continue
+            groups = match.groups()
+            result = {}
+            for key, value in pattern.items():
+                if key == "regexp":
+                    continue
+                result[key] = groups[value - 1]
+            results.append(result)
+    return results
+
+
+def test_could_not_install_deps_error():
+    log = (
+        "ERROR: could not install deps [flake7]; "
+        "v = InvocationError('/tmp/.tox/py310/bin/python -m pip install flake7', 1)"
+    )
+    assert match_problem(log) == [
+        {
+            "message": (
+                "could not install deps [flake7]; v = "
+                "InvocationError('/tmp/.tox/py310/bin/python -m pip install flake7', 1)"
+            ),
+            "severity": "ERROR",
+        }
+    ]
+
+
+def test_invocation_error_not_found():
+    log = "ERROR: InvocationError for command could not find executable flake9"
+    assert match_problem(log) == [
+        {
+            "message": "InvocationError for command could not find executable flake9",
+            "severity": "ERROR",
+        }
+    ]
+
+
+def test_invocation_error_non_zero_exit_code():
+    log = "ERROR: InvocationError for command /usr/bin/false (exited with code 1)"
+    assert match_problem(log) == [
+        {
+            "message": (
+                "InvocationError for command /usr/bin/false " "(exited with code 1)"
+            ),
+            "severity": "ERROR",
+        }
+    ]
+
+
+def test_warnings_on_allowlist_externals():
+    log = """WARNING: test command found but not installed in testenv
+  cmd: /bin/echo
+  env: /tmp/.tox/py310
+Maybe you forgot to specify a dependency?
+See also the allowlist_externals envconfig setting.
+
+DEPRECATION WARNING: this will be an error in tox 4 and above!
+"""
+    assert match_problem(log) == [
+        {
+            "message": "test command found but not installed in testenv",
+            "severity": "WARNING",
+        },
+        {
+            "message": "DEPRECATION WARNING: this will be an error in tox 4 and above!",
+            "severity": "WARNING",
+        },
+    ]


### PR DESCRIPTION
### Description
Add problem matchers to annotate errors on GitHub Actions: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md

### Expected Behavior
An error message like `ERROR: InvocationError for command could not find executable flake9` from tox is highlighted. Not all types of error messages may not be supported in this version.