### PR TITLE
Disable problem matchers only when running on GitHub Actions

### DIFF
--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -95,6 +95,9 @@ def tox_runtest_post(venv):
 @hookimpl
 def tox_cleanup(session):
     # This hook can be called multiple times especially when using parallel mode
+    if not is_running_on_actions():
+        return
+    verbosity2("disabling problem matcher")
     for owner in get_problem_matcher_owners():
         print("::remove-matcher owner={}::".format(owner))
 


### PR DESCRIPTION
### Description
Fix a but that `::remove-matcher owner=...::` was written even when tox-gh-actions is not running on GitHub Actions.

### Expected Behavior
Write `::remove-matcher owner=...::` only when tox-gh-actions is running on GitHub Actions.