### PR TITLE
Modernize .github/workflows and fix CI

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
       run: python -m build
     - name: Run twine check
       run: twine check dist/*
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-dist
         path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,19 +13,21 @@ jobs:
       matrix:
         # https://help.github.com/articles/virtual-environments-for-github-actions
         platform:
-          - ubuntu-18.04
           - ubuntu-latest  # ubuntu-20.04
-          - macos-latest  # macOS-10.15
-          - windows-2016
-          - windows-latest  # windows-2019
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev, pypy-2.7, pypy-3.7, pypy-3.8]
-        exclude:
-          # https://github.com/actions/setup-python/issues/311
-          - platform: macos-latest
-            python-version: pypy-3.7
+          - macos-latest  # macOS-11
+          - windows-latest  # windows-2022
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9]
 
     steps:
     - uses: actions/checkout@v3
+      if: ${{ ! startsWith(matrix.python-version, 'pypy-') }}
+    - uses: actions/checkout@v1
+      if: ${{ startsWith(matrix.python-version, 'pypy-') }}
+      # Using actions/checkout@v2 or later with pypy causes an error
+      # https://foss.heptapod.net/pypy/pypy/-/issues/3640
+      # py.error.ENOENT: [No such file or directory]:
+      # listdir('/home/runner/work/tox-gh-actions/tox-gh-actions/.tox/dist/
+      # warnings.warn(f\'"{wd.path}" is shallow and may cause errors\')',)
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
-target-version = ["py27", "py35", "py36", "py37", "py38", "py39", "py310"]
+target-version = ["py35", "py36", "py37", "py38", "py39", "py310"]
 
 [tool.coverage.paths]
 # For combining source file paths correctly


### PR DESCRIPTION
### Description
Use newer actions in `.github/workflows` for tox-gh-actions itself.

### Expected Behavior
No regressions.