### PR TITLE
Add missing backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ See [tox's documentation about factor-conditional settings](https://tox.readthed
 
 #### tox requires
 If your project uses [tox's `requires` configuration](https://tox.wiki/en/latest/config.html#conf-requires),
-you must add tox-gh-actions` to the `requires` configuration as well. Otherwise, tox-gh-actions won't be loaded as a tox plugin.
+you must add `tox-gh-actions` to the `requires` configuration as well. Otherwise, tox-gh-actions won't be loaded as a tox plugin.
 
 ```ini
 [tox]


### PR DESCRIPTION
### Description
- Found a backtick is missing at README.md

<img width="887" alt="Screen Shot 2022-07-20 at 5 12 59 PM" src="https://user-images.githubusercontent.com/13049936/179931939-b5009892-dd31-4d1a-9a43-e0ad84ec9c40.png">


### Expected Behavior
AS-IS
- you must add tox-gh-actions` to the `requires` configuration as well.

TO-BE
- you must add `tox-gh-actions` to the `requires` configuration as well.
