### PR TITLE
Show warning when tox-gh-actions couldn't find matching environments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ envlist =
 
 [gh-actions]
 python =
-    2.7: py27, flake8
+    2.7: py27
     3.5: py35
     3.6: py36
     3.7: py37

--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -53,6 +53,11 @@ def tox_configure(config):
 
     envlist = get_envlist_from_factors(config.envlist, factors)
     config.envlist_default = config.envlist = envlist
+    if len(envlist) == 0:
+        warning(
+            "tox-gh-actions couldn't find environments matching the provided factors "
+            "from envlist. Please use `tox -vv` to get more detailed logs."
+        )
     verbosity1("overriding envlist with: {}".format(envlist))
 
     if is_running_on_container():

--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -25,6 +25,23 @@ thread_locals.is_grouping_started = {}
 def tox_configure(config):
     # type: (Config) -> None
     verbosity1("running tox-gh-actions")
+
+    if is_running_on_container():
+        verbosity2(
+            "not enabling problem matcher as tox seems to be running on a container"
+        )
+        # Trying to add a problem matcher from a container without proper host mount can
+        # cause an error like the following:
+        # Unable to process command '::add-matcher::/.../matcher.json' successfully.
+    else:
+        verbosity2("enabling problem matcher")
+        print("::add-matcher::" + get_problem_matcher_file_path())
+
+    if not is_log_grouping_enabled(config):
+        verbosity2(
+            "disabling log line grouping on GitHub Actions based on the configuration"
+        )
+
     if not is_running_on_actions():
         verbosity1(
             "tox-gh-actions won't override envlist "
@@ -59,22 +76,6 @@ def tox_configure(config):
             "from envlist. Please use `tox -vv` to get more detailed logs."
         )
     verbosity1("overriding envlist with: {}".format(envlist))
-
-    if is_running_on_container():
-        verbosity2(
-            "not enabling problem matcher as tox seems to be running on a container"
-        )
-        # Trying to add a problem matcher from a container without proper host mount can
-        # cause an error like the following:
-        # Unable to process command '::add-matcher::/.../matcher.json' successfully.
-    else:
-        verbosity2("enabling problem matcher")
-        print("::add-matcher::" + get_problem_matcher_file_path())
-
-    if not is_log_grouping_enabled(config):
-        verbosity2(
-            "disabling log line grouping on GitHub Actions based on the configuration"
-        )
 
 
 @hookimpl


### PR DESCRIPTION
### Description
Show a warning message when tox-gh-actions couldn't find a list of environments which meet the given factors to make it easier for users to notice an issue with the configuration. (#66) 

### Expected Behavior
[![Image from Gyazo](https://i.gyazo.com/a94884d4d3e1b044a4ec137dcd84e215.png)](https://gyazo.com/a94884d4d3e1b044a4ec137dcd84e215)