### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-latest  # ubuntu-20.04
           - macos-latest  # macOS-11
           - windows-latest  # windows-2022
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', 3.11-dev, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 3.12-dev, pypy-2.7, pypy-3.7, pypy-3.8, pypy-3.9]
 
     steps:
     - uses: actions/checkout@v3
@@ -40,12 +40,12 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Upload coverage.xml
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.11' }}
       uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.11' }}
       uses: codecov/codecov-action@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
@@ -85,7 +86,7 @@ skip_missing_interpreters = true
 envlist =
     black
     flake8
-    {py27,py35,py36,py37,py38,py39,py310,pypy2,pypy3}-tox{312,315,latest}
+    {py27,py35,py36,py37,py38,py39,py310,py311,pypy2,pypy3}-tox{312,315,latest}
 
 [gh-actions]
 python =
@@ -96,6 +97,7 @@ python =
     3.8: py38, black, flake8
     3.9: py39
     3.10: py310
+    3.11: py311
     pypy-2: pypy2
     pypy-3: pypy3
 


### PR DESCRIPTION
### Description
Add Python 3.11 support.

### Expected Behavior
tox-gh-actions can run on Python 3.11 without issues.