### PR TITLE
tox4: Require tox 4.0.0b2 or later

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
 zip_safe = True
 python_requires = >=3.7
 install_requires =
-    tox >= 4.0.0a10, <5
+    tox >= 4.0.0b2, <5
 setup_requires =
     setuptools_scm[toml] >=6, <7
 


### PR DESCRIPTION
### Description
Require tox 4.0.0b2 or later. #59 

### Expected Behavior
No regressions.