### PR TITLE
Disable PR comments by Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
### Description
Disable PR comments by Codecov.

### Expected Behavior
Codecov's bot shouldn't leave comments on PRs by default.