### PR TITLE
Fix warning message when tox or tox -p 0 is used to run tox

### DIFF
--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -211,6 +211,10 @@ def is_log_grouping_enabled(options: Parsed) -> bool:
         elif isinstance(options.parallel, int) and options.parallel > 0:
             # Case for `tox p` or `tox -p <num>`
             return False
+        elif isinstance(options.parallel, int) and options.parallel = 0:
+            # Case for `tox` or `tox -p 0`
+            # tox will disable the parallel execution
+            return True
         logger.warning(
             "tox-gh-actions couldn't understand the parallel option. "
             "ignoring the given option: %s",


### PR DESCRIPTION
### Description
Fix the warning message when tox is started with certain arguments (#180)

```
py: tox-gh-actions couldn't understand the parallel option. ignoring the given option: 0
``` 

### Expected Behavior
Running tox with `tox` or `tox -p 0` shouldn't show the error message above.