### PR TITLE
Add CPython 3.12 and PyPy 3.10 to test suites

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         # https://help.github.com/articles/virtual-environments-for-github-actions
         platform:
-          - ubuntu-latest  # ubuntu-20.04
-          - macos-latest  # macOS-11
+          - ubuntu-latest  # ubuntu-22.04
+          - macos-latest  # macOS-12
           - windows-latest  # windows-2022
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 3.12-dev, pypy-3.7, pypy-3.8, pypy-3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10]
 
     steps:
     - uses: actions/checkout@v3
@@ -40,12 +40,12 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Upload coverage.xml
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.11' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.12' }}
       uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.11' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.12' }}
       uses: codecov/codecov-action@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing
@@ -89,6 +90,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311, black, flake8, mypy
+    3.12: py312
     pypy-3: pypy3
 
 [testenv]


### PR DESCRIPTION
### Description
Add CPython 3.12, and PyPy 3.10 to test suites.

### Expected Behavior
CI succeeds.