### PR TITLE
feat: Include abiflags in version dectection (enabling 3.13t)

### DIFF
--- a/src/tox_gh_actions/plugin.py
+++ b/src/tox_gh_actions/plugin.py
@@ -164,24 +164,27 @@ def get_python_version_keys() -> List[str]:
 
     Examples:
     - CPython 3.8.z => [3.8, 3]
-    - PyPy 3.6 (v7.3.z) => [pypy-3.6, pypy-3, pypy3]
+    - PyPy 3.6 (v7.3.z) => [pypy-3.6, pypy-3]
     - Pyston based on Python CPython 3.8.8 (v2.2) => [pyston-3.8, pyston-3]
+    - CPython 3.13.z (free-threading build) => [3.13t, 3.13, 3]
     """
-    major_version = str(sys.version_info[0])
-    major_minor_version = ".".join([str(i) for i in sys.version_info[:2]])
+    major, minor = sys.version_info[:2]
     if "PyPy" in sys.version:
         return [
-            "pypy-" + major_minor_version,
-            "pypy-" + major_version,
+            f"pypy-{major}.{minor}",
+            f"pypy-{major}",
         ]
     elif hasattr(sys, "pyston_version_info"):  # Pyston
         return [
-            "pyston-" + major_minor_version,
-            "pyston-" + major_version,
+            f"pyston-{major}.{minor}",
+            f"pyston-{major}",
         ]
     else:
         # Assume this is running on CPython
-        return [major_minor_version, major_version]
+        ret = [f"{major}.{minor}", f"{major}"]
+        if sys.abiflags:
+            ret.insert(0, f"{major}.{minor}{sys.abiflags}")
+        return ret
 
 
 def is_running_on_actions() -> bool:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -247,18 +247,27 @@ def test_get_envlist_from_factors(
 
 
 @pytest.mark.parametrize(
-    "version,info,expected",
+    "version,info,abiflags,expected",
     [
         (
             "3.8.1 (default, Jan 22 2020, 06:38:00) \n[GCC 9.2.0]",
             (3, 8, 1, "final", 0),
+            "",
             ["3.8", "3"],
         ),
         (
             "3.6.9 (1608da62bfc7, Dec 23 2019, 10:50:04)\n"
             "[PyPy 7.3.0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]",
             (3, 6, 9, "final", 0),
+            "",
             ["pypy-3.6", "pypy-3"],
+        ),
+        (
+            "3.13.0 experimental free-threading build (main, Oct 16 2024, 03:26:14) "
+            "[Clang 18.1.8 ]\n",
+            (3, 13, 0, "final", 0),
+            "t",
+            ["3.13t", "3.13", "3"],
         ),
     ],
 )
@@ -266,10 +275,12 @@ def test_get_version_keys(
     mocker: MockerFixture,
     version: str,
     info: Tuple[int, int, int, str, int],
+    abiflags: str,
     expected: List[str],
 ) -> None:
     mocker.patch("tox_gh_actions.plugin.sys.version", version)
     mocker.patch("tox_gh_actions.plugin.sys.version_info", info)
+    mocker.patch("tox_gh_actions.plugin.sys.abiflags", abiflags)
     assert plugin.get_python_version_keys() == expected
 
 


### PR DESCRIPTION
### Description

Currently, you can install free-threaded Python in GitHub actions (with deadsnakes or uv), and have `tox.ini` contain:

```
[gh-actions]
python =
  3.9: py39
  3.10: py310
  3.11: py311
  3.12: py312
  3.13: py313
  3.13t: py313t
```

But the version is detected as `3.13`, since only the version information is considered, not the abiflags. This enables abiflags, which in turn enables this use case.

This is important for setting conditions in tox that only apply to free-threading builds, such as setting `PYTHONGIL=0` or limiting dependencies to those with `py3` or `cp313t` wheels.

You can see it in action in https://github.com/nipy/nibabel/actions/runs/12217554525/job/34081969908:

```
ROOT: 226 I running tox-gh-actions [tox_gh_actions/plugin.py:28]
ROOT: 227 D original envlist: ['py39-none', 'py310-none', 'py311-none', 'py312-none', 'py313-none', 'py313t-none', 'py39-min', 'py39-full', 'py39-full-x86', 'py39-full-x64', 'py39-pre-x86', 'py39-pre-x64', 'py310-full-x86', 'py310-full-x64', 'py310-pre-x86', 'py310-pre-x64', 'py311-full-x86', 'py311-full-x64', 'py311-pre-x86', 'py311-pre-x64', 'py312-full-x64', 'py312-pre-x64', 'py313-full-x64', 'py313-pre-x64', 'py313t-full-x64', 'py313t-pre-x64', 'py313-dev-x64', 'install', 'doctest', 'style', 'typecheck'] [tox_gh_actions/plugin.py:42]
ROOT: 227 D Python versions: ['3.13t', '3.13', '3'] [tox_gh_actions/plugin.py:45]
ROOT: 228 D tox-gh-actions config: {'python': {'3.9': ['py39'], '3.10': ['py310'], '3.11': ['py311'], '3.12': ['py312'], '3.13': ['py313'], '3.13t': ['py313t']}, 'env': {'ARCH': {'x64': ['x64'], 'x86': ['x86'], 'arm64': ['arm64']}, 'DEPENDS': {'none': ['none', 'install'], 'pre': ['pre'], 'dev': ['dev'], 'full': ['full', 'install'], 'min': ['min']}}} [tox_gh_actions/plugin.py:48]
ROOT: 228 D got factors for Python version: 3.13t [tox_gh_actions/plugin.py:137]
ROOT: 228 D using the following factors to decide envlist: ['py313t-x64-full', 'py313t-x64-install'] [tox_gh_actions/plugin.py:51]
ROOT: 228 D expiring envlist cache to override [tox_gh_actions/plugin.py:121]
```

### Expected Behavior

When detecting a matching Python, 3.13t will be tried before falling back to 3.13 and 3.