### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12]
+        python-version: [3.13]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -30,7 +30,7 @@ jobs:
       run: python -m build
     - name: Run twine check
       run: twine check dist/*
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: tox-gh-actions-dist
         path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       matrix:
         # https://help.github.com/articles/virtual-environments-for-github-actions
         platform:
-          - ubuntu-latest  # ubuntu-22.04
+          - ubuntu-latest  # ubuntu-24.04
           - macos-13  # macos-13 (Intel)
           - macos-latest  # macos-14 (M1)
           - windows-latest  # windows-2022
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10]
         exclude:
           # Exclude the following configuration to avoid an error.
           # Error: The version '...' with architecture 'arm64' was not found for macOS 14.4.1.
@@ -49,12 +49,12 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Upload coverage.xml
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
       uses: actions/upload-artifact@v3
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
       uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ jobs:
           - macos-latest  # macos-14 (M1)
           - windows-latest  # windows-2022
         python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10]
+        include:
+          - platform: ubuntu-22.04
+            python-version: 3.7
         exclude:
           # Exclude the following configuration to avoid an error.
           # Error: The version '...' with architecture 'arm64' was not found for macOS 14.4.1.
@@ -26,6 +29,10 @@ jobs:
             python-version: 3.7
           - platform: macos-latest
             python-version: pypy-3.7
+          - platform: ubuntu-latest
+            python-version: 3.7
+          - platform: windows-latest
+            python-version: pypy-3.9
 
     steps:
     - uses: actions/checkout@v3
@@ -50,7 +57,7 @@ jobs:
       run: tox
     - name: Upload coverage.xml
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,9 +62,9 @@ testing =
     # but flake8 5.x requires an older version of it.
     flake8 >=6, <7; python_version>='3.8'
     mypy; platform_python_implementation=='CPython'
-    pytest >=7, <8
-    pytest-cov >=3, <4
-    pytest-mock >=3, <4
+    pytest >=7
+    pytest-cov >=4
+    pytest-mock >=3
     pytest-randomly >=3
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ envlist =
     black
     flake8
     mypy
-    {py37,py38,py39,py310,py311,pypy3}-toxlatest
+    {py37,py38,py39,py310,py311,py312,py313,pypy3}-toxlatest
 
 [gh-actions]
 python =
@@ -91,6 +91,7 @@ python =
     3.10: py310
     3.11: py311, black, flake8, mypy
     3.12: py312
+    3.13: py313
     pypy-3: pypy3
 
 [testenv]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Testing


### PR DESCRIPTION
### Description
Add Python 3.13 to the package metadata and the CI test matrix.

### Expected Behavior
tox-gh-actions officially supports Python 3.13.