### PR TITLE
Add PyPy 3.11 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - macos-13  # macos-13 (Intel)
           - macos-latest  # macos-14 (M1)
           - windows-latest  # windows-2022
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11]
         include:
           - platform: ubuntu-22.04
             python-version: 3.7


### PR DESCRIPTION
### Description
Add PyPy 3.11 to the CI test matrix.

### Expected Behavior
CI succeeds.