### PR TITLE
Pin third-party GitHub actions using commit hash

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -44,7 +44,7 @@ jobs:
           name: tox-gh-actions-dist
           path: dist
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
   github-release:
     needs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,4 +65,4 @@ jobs:
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
       if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1


### PR DESCRIPTION
### Description
Pin third-party GitHub actions using commit hash for better security.

### Expected Behavior
No regressions.