### PR TITLE
GitHub Actions: Add free threading Python 3.14t to the testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
         # https://help.github.com/articles/virtual-environments-for-github-actions
         platform:
           - ubuntu-latest  # ubuntu-24.04
-          - macos-13  # macos-13 (Intel)
-          - macos-latest  # macos-14 (M1)
-          - windows-latest  # windows-2022
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11]
+          - macos-15-intel  # macos-13 (Intel)
+          - macos-latest  # macos-15 (M1)
+          - windows-latest  # windows-2025
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, 3.14, 3.14t, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11]
         include:
           - platform: ubuntu-22.04
             python-version: 3.7
@@ -36,9 +36,9 @@ jobs:
           - platform: windows-latest
             python-version: pypy-3.9
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       if: ${{ ! startsWith(matrix.python-version, 'pypy-') }}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       if: ${{ startsWith(matrix.python-version, 'pypy-') }}
       # Using actions/checkout@v2 or later with pypy causes an error
       # https://foss.heptapod.net/pypy/pypy/-/issues/3640
@@ -57,12 +57,12 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Upload coverage.xml
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.14' }}
       uses: actions/upload-artifact@v4
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.14' }}
       uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 envlist =
     mypy
     pre-commit
-    {py37,py38,py39,py310,py311,py312,py313,pypy3}-toxlatest
+    {py37,py38,py39,py310,py311,py312,py313,py314,py314t,pypy3}-toxlatest
 
 [gh-actions]
 python =
@@ -15,7 +15,14 @@ python =
     3.10: py310
     3.11: py311, mypy
     3.12: py312
-    3.13: py313, pre-commit
+    3.13: py313
+    # What should we do here?!?
+    # Left side will always be Python `3.14` if it is python3.14 or python3.14t
+    # Right side must be `py314` or `py314t` so one or the other will always fail.
+    # Is there a way to OR the right side?  `3.14: py314 | py314t`
+    # 3.14: py314, pre-commit
+    3.14: py314, py314t, pre-commit
+    # 3.14t: py314t, pre-commit  # Never happepens.
     pypy-3: pypy3
 
 [testenv]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,8 +8,14 @@ requires_cpython = pytest.mark.skipif(
     sys.implementation.name != "cpython", reason="Requires CPython to run this test"
 )
 
+skip_if_free_threaded = pytest.mark.skipif(
+    sys.version_info >= (3, 13) and not sys._is_gil_enabled(),
+    reason="Fails on free threaded builds",
+)
+
 
 @pytest.mark.integration
+@skip_if_free_threaded
 @requires_cpython
 def test_sunny_day_with_legacy_command(
     monkeypatch: MonkeyPatch, tox_project: ToxProjectCreator
@@ -40,6 +46,7 @@ python =
 
 
 @pytest.mark.integration
+@skip_if_free_threaded
 @requires_cpython
 def test_sunny_day_with_run_command(
     monkeypatch: MonkeyPatch, tox_project: ToxProjectCreator


### PR DESCRIPTION
### Related to:
* #199

### Description
GitHub Actions: Add free threading Python 3.14t to the testing
* https://www.python.org/downloads/release/python-3140/

Is there a way to make these two tests pass under free threading?

```diff
+ skip_if_free_threaded = pytest.mark.skipif(
+     sys.version_info >= (3, 13) and not sys._is_gil_enabled(),
+     reason="Fails on free threaded builds",
+ )

+ @skip_if_free_threaded
  def test_sunny_day_with_legacy_command(

  [ ... ]

+ @skip_if_free_threaded
  def test_sunny_day_with_run_command(
```

### Expected Behavior
All tests continue to pass

~@effigies, your review please.~