### PR TITLE
Add PyPI project URL to packaging workflow environment

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -34,7 +34,9 @@ jobs:
       - build
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tox-gh-actions
     permissions:
       id-token: write # Required for using pypa/gh-actions-pypi-publish
     steps:


### PR DESCRIPTION
### Description
This adds the project URL to the PyPI environment configuration, which will be displayed in the GitHub deployment view for better visibility and easier access to the published package.

### Expected Behavior
The publish to PyPI should succeed.