### PR TITLE
GitHub Actions: macOS 13 runner image is closing down

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,35 +16,25 @@ jobs:
         # https://help.github.com/articles/virtual-environments-for-github-actions
         platform:
           - ubuntu-latest  # ubuntu-24.04
-          - macos-13  # macos-13 (Intel)
-          - macos-latest  # macos-14 (M1)
-          - windows-latest  # windows-2022
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 3.13, 3.14, pypy-3.7, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11]
+          - macos-15-intel  # macos-15 (Intel)
+          - macos-latest  # macos-15 (Apple Silicon ARM)
+          - windows-latest  # windows-2025
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 3.13, 3.14, pypy-3.8, pypy-3.9, pypy-3.10, pypy-3.11, graalpy-25]
         include:
           - platform: ubuntu-22.04
             python-version: 3.7
-        exclude:
-          # Exclude the following configuration to avoid an error.
-          # Error: The version '...' with architecture 'arm64' was not found for macOS 14.4.1.
-          # The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - platform: macos-latest
-            python-version: 3.7
-          - platform: macos-latest
+          - platform: ubuntu-22.04
             python-version: pypy-3.7
-          - platform: ubuntu-latest
-            python-version: 3.7
+        exclude:
+          # GitHub Actions Windows runners do not support PyPy 3.9 or GraalPy 25.
+          # The list of all available versions can be found here:
+          # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
           - platform: windows-latest
             python-version: pypy-3.9
+          - platform: windows-latest
+            python-version: graalpy-25
     steps:
     - uses: actions/checkout@v5
-      if: ${{ ! startsWith(matrix.python-version, 'pypy-') }}
-    - uses: actions/checkout@v5
-      if: ${{ startsWith(matrix.python-version, 'pypy-') }}
-      # Using actions/checkout@v2 or later with pypy causes an error
-      # https://foss.heptapod.net/pypy/pypy/-/issues/3640
-      # py.error.ENOENT: [No such file or directory]:
-      # listdir('/home/runner/work/tox-gh-actions/tox-gh-actions/.tox/dist/
-      # warnings.warn(f\'"{wd.path}" is shallow and may cause errors\')',)
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -58,12 +48,12 @@ jobs:
     - name: Test with tox
       run: tox
     - name: Upload coverage.xml
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.14' }}
       uses: actions/upload-artifact@v4
       with:
         name: tox-gh-actions-coverage
         path: coverage.xml
         if-no-files-found: error
     - name: Upload coverage.xml to codecov
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.13' }}
+      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.14' }}
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1


### PR DESCRIPTION
Upgrade from deprecated `macos-13` GitHub Actions runner to `macos-15-intel`.
* https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |
* Let's prepare for actions/runner-images#13046

Should a set of test runs be made on `macos-26`?

---
Also added GraalPy 25 Python to the testing, except on Windows, where it is not supported.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#graalpy

---
Also, reduced the testing of Python 3.7 and PyPy3.7, as both Py3.8 and Py3.9 are now also end-of-life.
* https://devguide.python.org/versions/